### PR TITLE
Specify version for CI/CD tools

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: psf/black@stable
         with:
           options: "--check --verbose"
+          version: "23.1.0"
 
   flake8:
     runs-on: ubuntu-20.04
@@ -24,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
+          pip install flake8==5.0.4
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest coverage
+          pip install pytest==7.2.1 coverage
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Unit tests
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-black
-flake8
-pytest
+black==23.1.0
+flake8==5.0.4
+pytest==7.2.1


### PR DESCRIPTION
Version of black, flake8 and pytest are pre-defined to avoid local and remote conflicts